### PR TITLE
Match this error regex with the underlying go import error text

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -3,15 +3,16 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
 	gofrogio "github.com/jfrog/gofrog/io"
 	"github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 func prepareRegExp() error {
@@ -42,8 +43,8 @@ func prepareGlobalRegExp() error {
 	}
 
 	if unrecognizedImportRegExp == nil {
-		log.Debug("Initializing unrecognized import path regexp")
-		unrecognizedImportRegExp, err = initRegExp(`[^go:]([^\/\r\n]+\/[^\r\n\s:]*).*(unrecognized import path)`, Error)
+		log.Debug("Initializing unknown import path regexp")
+		unrecognizedImportRegExp, err = initRegExp(`[^go:]([^\/\r\n]+\/[^\r\n\s:]*).*(unknown import path)`, Error)
 		if err != nil {
 			return err
 		}
@@ -91,7 +92,7 @@ func Error(pattern *gofrogio.CmdOutputPattern) (string, error) {
 		return "", errorutils.CheckError(err)
 	}
 	if len(pattern.MatchedResults) >= 3 {
-		return "", errors.New(pattern.MatchedResults[2] + ":" + strings.TrimSpace(pattern.MatchedResults[1]))
+		return "", errors.New(pattern.MatchedResults[2] + ": " + strings.TrimSpace(pattern.MatchedResults[0]))
 	}
 	return "", errors.New(fmt.Sprintf("Regex found the following values: %s", pattern.MatchedResults))
 }


### PR DESCRIPTION
Note that [here](https://github.com/golang/go/blob/aa95a1eb5a3423d96873946d47c663bdc8f3565e/src/cmd/go/internal/load/pkg.go#L534) it's `unknown`, not `unrecognized`.

This will change this:
<img width="186" alt="screen shot 2019-02-26 at 7 04 38 pm" src="https://user-images.githubusercontent.com/2424906/53462859-1ba64700-39fa-11e9-95a6-48f98d29af1f.png">

To this:
<img width="484" alt="screen shot 2019-02-26 at 7 10 29 pm" src="https://user-images.githubusercontent.com/2424906/53462893-38427f00-39fa-11e9-9e8b-6bd0dfb26b26.png">

I also noticed that the go command error message was getting cut off, so I bumped up that MatchedResults index

Cheers!