### PR TITLE
Handle dependency resolution output when resolving dependencies

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,15 +2,16 @@ package cmd
 
 import (
 	"errors"
-	gofrogcmd "github.com/jfrog/gofrog/io"
-	"github.com/jfrog/jfrog-client-go/utils/errorutils"
-	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
-	"github.com/jfrog/jfrog-client-go/utils/log"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	gofrogcmd "github.com/jfrog/gofrog/io"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 var protocolRegExp *gofrogcmd.CmdOutputPattern
@@ -75,7 +76,7 @@ func RunGo(goArg []string) error {
 	if err != nil {
 		return err
 	}
-	_, _, err = gofrogcmd.RunCmdWithOutputParser(goCmd, true, protocolRegExp, notFoundRegExp, unrecognizedImportRegExp, unknownRevisionRegExp, notFoundZipRegExp)
+	_, _, _, err = gofrogcmd.RunCmdWithOutputParser(goCmd, true, protocolRegExp, notFoundRegExp, unrecognizedImportRegExp, unknownRevisionRegExp, notFoundZipRegExp)
 	return errorutils.CheckError(err)
 }
 
@@ -124,7 +125,7 @@ func GetDependenciesGraph() (map[string]bool, error) {
 	if err != nil {
 		return nil, err
 	}
-	output, _, err := gofrogcmd.RunCmdWithOutputParser(goCmd, true, protocolRegExp, notFoundRegExp, unrecognizedImportRegExp, unknownRevisionRegExp)
+	output, errorOutput, _, err := gofrogcmd.RunCmdWithOutputParser(goCmd, true, protocolRegExp, notFoundRegExp, unrecognizedImportRegExp, unknownRevisionRegExp)
 	if len(output) != 0 {
 		log.Debug(output)
 	}
@@ -141,7 +142,7 @@ func GetDependenciesGraph() (map[string]bool, error) {
 		return nil, err
 	}
 
-	return outputToMap(output), errorutils.CheckError(err)
+	return outputToMap(output, errorOutput), errorutils.CheckError(err)
 }
 
 // Using go mod download command to download all the dependencies before publishing to Artifactory
@@ -175,7 +176,7 @@ func RunGoModInit(moduleName string) error {
 	}
 
 	goCmd.Command = []string{"mod", "init", moduleName}
-	_, _, err = gofrogcmd.RunCmdWithOutputParser(goCmd, true)
+	_, _, _, err = gofrogcmd.RunCmdWithOutputParser(goCmd, true)
 	return err
 }
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 func TestOutputToMap(t *testing.T) {
-	content := `go: finding github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db
+	errorOutput := `go: finding rsc.io/quote v1.4.16
+go: finding github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db
 go: finding github.com/nwaples/rardecode v0.0.0-20171029023500-e06696f847ae
 go: finding github.com/pierrec/lz4 v2.0.5+incompatible
 go: finding github.com/ulikunitz/xz v0.5.4
@@ -19,7 +20,9 @@ go: finding golang.org/x/tools v0.0.0-20181006002542-f60d9635b16a
 go: finding golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2
 go: finding rsc.io/sampler v1.3.0
 go: finding golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c
-github.com/you/hello github.com/dsnet/compress@v0.0.0-20171208185109-cc9eb1d7ad76
+`
+
+	stdOutput := `github.com/you/hello github.com/dsnet/compress@v0.0.0-20171208185109-cc9eb1d7ad76
 github.com/you/hello github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db
 github.com/you/hello github.com/mholt/archiver@v2.1.0+incompatible
 github.com/you/hello github.com/nwaples/rardecode@v0.0.0-20171029023500-e06696f847ae
@@ -30,10 +33,11 @@ github.com/you/hello golang.org/x/tools@v0.0.0-20181006002542-f60d9635b16a
 github.com/you/hello rsc.io/quote@v1.5.2
 rsc.io/quote@v1.5.2 rsc.io/sampler@v1.3.0
 rsc.io/sampler@v1.3.0 golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c
-	`
+`
 
-	actual := outputToMap(content)
+	actual := outputToMap(stdOutput, errorOutput)
 	expected := map[string]bool{
+		"rsc.io/quote@v1.4.16": true,
 		"github.com/dsnet/compress@v0.0.0-20171208185109-cc9eb1d7ad76":    true,
 		"github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db":     true,
 		"github.com/mholt/archiver@v2.1.0+incompatible":                   true,

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -151,9 +151,11 @@ func outputToMap(output string, errorOutput string) map[string]bool {
 
 	// Parse dependency resolution output, sent to the error output by go mod graph
 	lineOutput = strings.Split(errorOutput, "\n")
+	prefix := "go: finding"
+	index := len(prefix) + 1
 	for _, line := range lineOutput {
-		if strings.HasPrefix(line, "go: finding") {
-			lineContent := line[12:]
+		if strings.HasPrefix(line, prefix) {
+			lineContent := line[index:]
 			dependencyParts := strings.Split(lineContent, " ")
 			dependency := fmt.Sprintf("%s@%s", dependencyParts[0], dependencyParts[1])
 			mapOfDeps[dependency] = true


### PR DESCRIPTION
Go modules requirements resolution uses the [minimum version selection](https://github.com/golang/go/wiki/Modules#version-selection) possible when resolving requirements. This means that when we run go mod graph, if there is multiple versions of the same module declared as requirements by a module dependencies, only one of them will be used and show in the command output. Even though only a single version will be used, during the requirements resolution phase all the described versions mod files will be fetched by Go to discover the minimum version possible.

In order to make modules resolvable from GoCenter, we need to make all those versions available, so the requirements resolution phase can succeed when resolving from there. Right now, the current implementation only uses the results of go mod graph to discover the list of modules that need to be processed, which is causing versions to be missing in cases where a dependency override is happening. 

The most basic scenario that can illustrate that is

```
A@v1.0.0 -> B@v1.0.0
        |-> C@v1.0.0 -> B@v1.1.0 
```
Running go mod graph on A@v1.0.0 will show only B@v1.1.0 (minimum version possible). It will also update A's go.mod file to reflect that version.

This PR aims to fix this issue, by using the modules fetched during requirements resolution phase to the output of go mod graph as the list of a modules dependencies that need to be processed.

Note: This PR requires https://github.com/jfrog/gofrog/pull/15 to be merged