### PR TITLE
Fixed 404 regex to handle versions with 404 suffix

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -35,7 +35,7 @@ func prepareGlobalRegExp() error {
 
 	if notFoundRegExp == nil {
 		log.Debug("Initializing not found regexp")
-		notFoundRegExp, err = initRegExp(`^go: ([^\/\r\n]+\/[^\r\n\s:]*).*(404 Not Found[\s]?)$`, Error)
+		notFoundRegExp, err = initRegExp(`^go: ([^\/\r\n]+\/[^\r\n\s:]*).*( 404( Not Found)?[\s]?)$`, Error)
 		if err != nil {
 			return err
 		}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -35,7 +35,7 @@ func prepareGlobalRegExp() error {
 
 	if notFoundRegExp == nil {
 		log.Debug("Initializing not found regexp")
-		notFoundRegExp, err = initRegExp(`^go: ([^\/\r\n]+\/[^\r\n\s:]*).*(404( Not Found)?[\s]?)$`, Error)
+		notFoundRegExp, err = initRegExp(`^go: ([^\/\r\n]+\/[^\r\n\s:]*).*(404 Not Found[\s]?)$`, Error)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The previous implementation would mistake the following Go command output as a 404:
```
go: finding github.com/integrii/flaggy v0.0.0-20190517180110-07ea7eb77404
```
This PR makes the `Not Found` group in the regex not optional.