### PR TITLE
RunCmdWithOutputParser stops printing output to stdout

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -172,9 +172,9 @@ func GetDependenciesList(projectDir string) (map[string]bool, error) {
 	var output string
 	var executionError error
 	if performPasswordMask {
-		output, _, _, executionError = gofrogcmd.RunCmdWithOutputParser(goCmd, true, protocolRegExp)
+		output, _, _, executionError = gofrogcmd.RunCmdWithOutputParser(goCmd, false, protocolRegExp)
 	} else {
-		output, _, _, executionError = gofrogcmd.RunCmdWithOutputParser(goCmd, true)
+		output, _, _, executionError = gofrogcmd.RunCmdWithOutputParser(goCmd, false)
 	}
 
 	if len(output) != 0 {


### PR DESCRIPTION
The “jfrog rt go-publish” command output reaches into stdout and therefore gets mixed with the detailed summary.
Therefore 'RunCmdWithOutputParser' should stop printing to the stdout